### PR TITLE
dep: Update stringio to 3.0.7 to support Ruby 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,11 @@ gem 'tempfile'
 gem "prime"
 gem "rdoc", "~> 6.4.0"
 
+# FIXME: Workaround for Parser 3.2.2.2 or lower with Ruby 3.3.0dev.
+# When the Praser gem releases a new version of Racc that includes the runtime dependencies,
+# it will be able to upgrade the Parser gem dependency and remove the workaround.
+gem 'racc', '>= 1.6.2'
+
 # Test gems
 gem "rbs-amber", path: "test/assets/test-gem"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     psych (4.0.6)
       stringio
     public_suffix (5.0.1)
+    racc (1.7.0)
     rainbow (3.1.1)
     rake (13.0.6)
     rake-compiler (1.2.2)
@@ -104,6 +105,7 @@ DEPENDENCIES
   json-schema
   minitest
   prime
+  racc (>= 1.6.2)
   rake
   rake-compiler
   rbs!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     singleton (0.1.1)
     sorbet-runtime (0.5.10827)
     stackprof (0.2.25)
-    stringio (3.0.6)
+    stringio (3.0.7)
     strong_json (2.1.2)
     syntax_tree (6.1.1)
       prettier_print (>= 1.2.0)


### PR DESCRIPTION
stringio-3.0.7 was released at 2023/6/2 to support Ruby 3.3. https://github.com/ruby/stringio/blob/master/NEWS.md#307---2023-06-02

This upgrade it from 3.0.6 to 3.0.7 to resolve errors for master-nightly-* tests.